### PR TITLE
Initial preferences implementation.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,3 +28,5 @@ migrate_working_dir/
 .dart_tool/
 .packages
 build/
+
+coverage

--- a/README.md
+++ b/README.md
@@ -7,3 +7,14 @@ A client-side Flutter library to interact with user-facing Knock features, such 
 ## Documentation
 
 See the [documentation](https://docs.knock.app/notification-feeds/bring-your-own-ui) for usage examples.
+
+## Package Development
+
+### Code generation
+Code generation is limited to supporting JSON serialization/deserization of API messages. If you need to 
+adust the generated code you will want to run this command from the top level directory.
+```
+dart run build_runner build --delete-conflicting-outputs
+```
+
+Generated files are checked into version control because they are part of the released packaged.

--- a/analysis_options.yaml
+++ b/analysis_options.yaml
@@ -1,4 +1,4 @@
 include: package:flutter_lints/flutter.yaml
 
-# Additional information about this file can be found at
-# https://dart.dev/guides/language/analysis-options
+analyzer:
+  exclude: ["**/**.g.dart"]

--- a/build.yaml
+++ b/build.yaml
@@ -1,0 +1,7 @@
+targets:
+  $default:
+    builders:
+      source_gen:combining_builder:
+        options:
+          preamble: |
+            // coverage:ignore-file

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -1,3 +1,5 @@
+import 'dart:developer' as developer;
+
 import 'package:flutter/material.dart';
 import 'package:knock_flutter/knock_flutter.dart';
 
@@ -29,7 +31,7 @@ class KnockPage extends StatefulWidget {
 }
 
 class _KnockPageState extends State<KnockPage> {
-  Knock? _knock;
+  late Knock _knock;
 
   @override
   void initState() {
@@ -51,11 +53,44 @@ class _KnockPageState extends State<KnockPage> {
     /// https://codewithandrea.com/articles/flutter-api-keys-dart-define-env-files/#new-in-flutter-37-use---dart-define-from-file
     /// to learn more about this approach.
     _knock = Knock(const String.fromEnvironment("KNOCK_API_KEY"));
+    _knock.authenticate('1');
+  }
+
+  // ignore: unused_element
+  void _getAllPreferences() async {
+    final List<PreferenceSet> all = await _knock.preferences.getAll();
+    developer.log(all.toString());
+  }
+
+  // ignore: unused_element
+  void _getPreferences() async {
+    final PreferenceSet preferences = await _knock.preferences.get();
+    developer.log(preferences.toString());
+  }
+
+  // ignore: unused_element
+  void _setPreferences() async {
+    final PreferenceSet preferences = await _knock.preferences.set(
+      SetPreferencesProperties(
+        categories: {
+          'dinosaur-proximity': WorkflowPreferenceSetting.workflow(true),
+        },
+        workflows: {
+          'unix-servers': WorkflowPreferenceSetting.channelTypePreferences({
+            ChannelType.inAppFeed: true,
+          }),
+        },
+        channelTypes: {
+          ChannelType.email: false,
+        },
+      ),
+    );
+    developer.log(preferences.toString());
   }
 
   @override
   void dispose() {
-    _knock?.dispose();
+    _knock.dispose();
     super.dispose();
   }
 

--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -83,6 +83,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "4.0.2"
+  json_annotation:
+    dependency: transitive
+    description:
+      name: json_annotation
+      sha256: b10a7b2ff83d83c777edba3c6a0f97045ddadd56c944e1a23a3fdf43a1bf4467
+      url: "https://pub.dev"
+    source: hosted
+    version: "4.8.1"
   knock_flutter:
     dependency: "direct main"
     description:

--- a/lib/knock_flutter.dart
+++ b/lib/knock_flutter.dart
@@ -1,3 +1,5 @@
 library knock_flutter;
 
 export 'src/knock.dart';
+export 'src/preferences_client.dart';
+export 'src/model/preferences.dart';

--- a/lib/src/api_client.dart
+++ b/lib/src/api_client.dart
@@ -1,5 +1,11 @@
+import 'dart:developer' as developer;
+
 import 'package:http/http.dart' as http;
+
 import 'package:knock_flutter/knock_flutter.dart';
+import 'package:knock_flutter/src/model/api_response.dart';
+
+typedef ApiRequestBuilder = Future<http.Response> Function();
 
 class ApiClient extends http.BaseClient {
   final Knock knock;
@@ -9,8 +15,6 @@ class ApiClient extends http.BaseClient {
     this.knock, {
     http.Client? client,
   }) : _client = client ?? http.Client();
-
-  Uri path(String path) => Uri.parse('${knock.host}/$path');
 
   @override
   Future<http.StreamedResponse> send(http.BaseRequest request) {
@@ -25,6 +29,34 @@ class ApiClient extends http.BaseClient {
 
     return _client.send(request);
   }
+
+  Future<ApiResponse> doGet(String path) async {
+    return _doRequest(() => get(_usingPath(path)));
+  }
+
+  Future<ApiResponse> doPut(String path, {Object? body}) async {
+    return _doRequest(() => put(_usingPath(path), body: body));
+  }
+
+  Future<ApiResponse> _doRequest(ApiRequestBuilder requestBuilder) async {
+    try {
+      final response = await requestBuilder();
+      final status = response.statusCode;
+      final statusCode = status < 300 ? StatusCode.ok : StatusCode.error;
+      final body = response.body;
+      return ApiResponse(status: status, statusCode: statusCode, body: body);
+    } catch (error) {
+      developer.log('Failed API request', error: error);
+
+      return ApiResponse(
+        status: 500,
+        statusCode: StatusCode.error,
+        error: error,
+      );
+    }
+  }
+
+  Uri _usingPath(String path) => Uri.parse('${knock.host}$path');
 
   void dispose() {
     _client.close();

--- a/lib/src/knock.dart
+++ b/lib/src/knock.dart
@@ -1,6 +1,5 @@
-import 'dart:developer' as developer;
-
 import 'package:knock_flutter/src/api_client.dart';
+import 'package:knock_flutter/src/preferences_client.dart';
 
 // Default endpoint that the Knock SDK will use.
 const _defaultHost = "https://api.knock.app";
@@ -24,6 +23,7 @@ class Knock {
   String? _userId;
   String? _userToken;
   ApiClient? _apiClient;
+  PreferencesClient? _preferencesClient;
 
   Knock(this.apiKey, {KnockOptions? options})
       : host = options?.host ?? _defaultHost {
@@ -59,9 +59,9 @@ class Knock {
     return (userId?.isNotEmpty ?? false);
   }
 
-  ApiClient client() {
+  void _assertAuthenticated() {
     if (!isAuthenticated()) {
-      developer.log("""
+      throw StateError("""
         [Knock] You must call authenticate(userId, userToken) first before 
         trying to make a request. Typically you'll see this message when 
         you're creating a feed instance before having called authenticate with 
@@ -69,8 +69,18 @@ class Knock {
         to Knock on behalf of.
         """);
     }
+  }
+
+  ApiClient client() {
+    _assertAuthenticated();
 
     return _apiClient ??= ApiClient(this);
+  }
+
+  PreferencesClient get preferences {
+    _assertAuthenticated();
+
+    return _preferencesClient ??= PreferencesClient(this, client());
   }
 
   /// Releases any connected resources used by this this instance.

--- a/lib/src/model/api_response.dart
+++ b/lib/src/model/api_response.dart
@@ -1,0 +1,25 @@
+import 'package:equatable/equatable.dart';
+
+enum StatusCode { ok, error }
+
+class ApiResponse extends Equatable {
+  final int status;
+  final StatusCode statusCode;
+  final String? body;
+  final Object? error;
+
+  const ApiResponse({
+    required this.status,
+    required this.statusCode,
+    this.body,
+    this.error,
+  });
+
+  @override
+  List<Object?> get props => [status, statusCode, body, error];
+
+  @override
+  String toString() {
+    return 'ApiResponse{status=$status, statusCode=$statusCode, body=$body, error=$error}';
+  }
+}

--- a/lib/src/model/preferences.dart
+++ b/lib/src/model/preferences.dart
@@ -1,0 +1,165 @@
+import 'package:equatable/equatable.dart';
+import 'package:json_annotation/json_annotation.dart';
+
+part 'preferences.g.dart';
+
+enum ChannelType {
+  email,
+  @JsonValue('in_app_feed')
+  inAppFeed,
+  sms,
+  push,
+  chat,
+  http,
+}
+
+typedef ChannelTypePreferences = Map<ChannelType, bool>;
+
+// This class is only used for JSON encoding/decoding. The channel_types value
+// is what will be exposed in the public SDK.
+@JsonSerializable()
+class _ChannelTypesJson {
+  @JsonKey(name: 'channel_types')
+  final ChannelTypePreferences channelTypes;
+
+  const _ChannelTypesJson({
+    required this.channelTypes,
+  });
+
+  factory _ChannelTypesJson.fromJson(Map<String, dynamic> json) =>
+      _$ChannelTypesJsonFromJson(json);
+
+  Map<String, dynamic> toJson() => _$ChannelTypesJsonToJson(this);
+}
+
+class WorkflowPreferenceSetting extends Equatable {
+  final bool _isWorkflow;
+  final bool? _workflow;
+  final ChannelTypePreferences? _channelPreferences;
+
+  factory WorkflowPreferenceSetting.workflow(bool workflow) =>
+      WorkflowPreferenceSetting._(true, workflow, null);
+
+  factory WorkflowPreferenceSetting.channelTypePreferences(
+          ChannelTypePreferences channelTypePreferences) =>
+      WorkflowPreferenceSetting._(false, null, channelTypePreferences);
+
+  const WorkflowPreferenceSetting._(
+      this._isWorkflow, this._workflow, this._channelPreferences);
+
+  bool get isWorkflow => _isWorkflow;
+
+  bool get workflow => _workflow!;
+
+  ChannelTypePreferences get channelPreferences => _channelPreferences!;
+
+  @override
+  String toString() {
+    return 'WorkflowPreferenceSetting{_isWorkflow=$_isWorkflow, _workflow=$_workflow, _channelPreferences=$_channelPreferences}';
+  }
+
+  @override
+  List<Object?> get props => [_isWorkflow, _workflow, _channelPreferences];
+}
+
+typedef WorkflowPreferences = Map<String, WorkflowPreferenceSetting>;
+
+@JsonSerializable()
+class SetPreferencesProperties extends Equatable {
+  @JsonKey(name: 'channel_types')
+  final ChannelTypePreferences? channelTypes;
+
+  @JsonKey(
+      toJson: _workflowPreferencesToJson,
+      fromJson: _workflowPreferencesFromJson)
+  final WorkflowPreferences? workflows;
+
+  @JsonKey(
+      toJson: _workflowPreferencesToJson,
+      fromJson: _workflowPreferencesFromJson)
+  final WorkflowPreferences? categories;
+
+  const SetPreferencesProperties({
+    this.channelTypes,
+    this.workflows,
+    this.categories,
+  });
+
+  Map<String, dynamic> toJson() => _$SetPreferencesPropertiesToJson(this);
+
+  @override
+  List<Object?> get props => [channelTypes, workflows, categories];
+
+  @override
+  String toString() {
+    return 'SetPreferencesProperties{channelTypes=$channelTypes, workflows=$workflows, categories=$categories}';
+  }
+}
+
+@JsonSerializable(createToJson: false)
+class PreferenceSet extends Equatable {
+  final String id;
+
+  @JsonKey(name: 'channel_types')
+  final ChannelTypePreferences? channelTypes;
+
+  @JsonKey(
+      toJson: _workflowPreferencesToJson,
+      fromJson: _workflowPreferencesFromJson)
+  final WorkflowPreferences? workflows;
+
+  @JsonKey(
+      toJson: _workflowPreferencesToJson,
+      fromJson: _workflowPreferencesFromJson)
+  final WorkflowPreferences? categories;
+
+  const PreferenceSet({
+    required this.id,
+    required this.channelTypes,
+    required this.workflows,
+    required this.categories,
+  });
+
+  factory PreferenceSet.fromJson(Map<String, dynamic> json) =>
+      _$PreferenceSetFromJson(json);
+
+  @override
+  List<Object?> get props => [id, channelTypes, workflows, categories];
+
+  @override
+  String toString() {
+    return 'PreferenceSet{id=$id, channelTypes=$channelTypes, workflows=$workflows, categories=$categories}';
+  }
+}
+
+dynamic _workflowPreferencesToJson(WorkflowPreferences? value) {
+  return value?.map((key, value) => MapEntry(
+        key,
+        _workflowPreferenceSettingToJson(value),
+      ));
+}
+
+WorkflowPreferences? _workflowPreferencesFromJson(Map<String, dynamic>? json) {
+  return json?.map((key, value) => MapEntry(
+        key,
+        _workflowPreferenceSettingFromJson(value),
+      ));
+}
+
+dynamic _workflowPreferenceSettingToJson(WorkflowPreferenceSetting value) {
+  if (value.isWorkflow) {
+    return value.workflow;
+  } else {
+    return _ChannelTypesJson(channelTypes: value.channelPreferences).toJson();
+  }
+}
+
+WorkflowPreferenceSetting _workflowPreferenceSettingFromJson(dynamic json) {
+  if (json is bool) {
+    return WorkflowPreferenceSetting.workflow(json);
+  } else {
+    final channelTypes = _ChannelTypesJson.fromJson(json);
+    return WorkflowPreferenceSetting.channelTypePreferences(
+        channelTypes.channelTypes);
+  }
+}

--- a/lib/src/model/preferences.g.dart
+++ b/lib/src/model/preferences.g.dart
@@ -1,0 +1,64 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+// coverage:ignore-file
+
+part of 'preferences.dart';
+
+// **************************************************************************
+// JsonSerializableGenerator
+// **************************************************************************
+
+_ChannelTypesJson _$ChannelTypesJsonFromJson(Map<String, dynamic> json) =>
+    _ChannelTypesJson(
+      channelTypes: (json['channel_types'] as Map<String, dynamic>).map(
+        (k, e) => MapEntry($enumDecode(_$ChannelTypeEnumMap, k), e as bool),
+      ),
+    );
+
+Map<String, dynamic> _$ChannelTypesJsonToJson(_ChannelTypesJson instance) =>
+    <String, dynamic>{
+      'channel_types': instance.channelTypes
+          .map((k, e) => MapEntry(_$ChannelTypeEnumMap[k]!, e)),
+    };
+
+const _$ChannelTypeEnumMap = {
+  ChannelType.email: 'email',
+  ChannelType.inAppFeed: 'in_app_feed',
+  ChannelType.sms: 'sms',
+  ChannelType.push: 'push',
+  ChannelType.chat: 'chat',
+  ChannelType.http: 'http',
+};
+
+SetPreferencesProperties _$SetPreferencesPropertiesFromJson(
+        Map<String, dynamic> json) =>
+    SetPreferencesProperties(
+      channelTypes: (json['channel_types'] as Map<String, dynamic>?)?.map(
+        (k, e) => MapEntry($enumDecode(_$ChannelTypeEnumMap, k), e as bool),
+      ),
+      workflows: _workflowPreferencesFromJson(
+          json['workflows'] as Map<String, dynamic>?),
+      categories: _workflowPreferencesFromJson(
+          json['categories'] as Map<String, dynamic>?),
+    );
+
+Map<String, dynamic> _$SetPreferencesPropertiesToJson(
+        SetPreferencesProperties instance) =>
+    <String, dynamic>{
+      'channel_types': instance.channelTypes
+          ?.map((k, e) => MapEntry(_$ChannelTypeEnumMap[k]!, e)),
+      'workflows': _workflowPreferencesToJson(instance.workflows),
+      'categories': _workflowPreferencesToJson(instance.categories),
+    };
+
+PreferenceSet _$PreferenceSetFromJson(Map<String, dynamic> json) =>
+    PreferenceSet(
+      id: json['id'] as String,
+      channelTypes: (json['channel_types'] as Map<String, dynamic>?)?.map(
+        (k, e) => MapEntry($enumDecode(_$ChannelTypeEnumMap, k), e as bool),
+      ),
+      workflows: _workflowPreferencesFromJson(
+          json['workflows'] as Map<String, dynamic>?),
+      categories: _workflowPreferencesFromJson(
+          json['categories'] as Map<String, dynamic>?),
+    );

--- a/lib/src/preferences_client.dart
+++ b/lib/src/preferences_client.dart
@@ -1,0 +1,60 @@
+import 'dart:convert';
+
+import 'package:knock_flutter/knock_flutter.dart';
+import 'package:knock_flutter/src/api_client.dart';
+import 'package:knock_flutter/src/model/api_response.dart';
+
+class PreferenceOptions {
+  static const _defaultPreferenceSetId = 'default';
+
+  final String preferenceSetId;
+
+  const PreferenceOptions({this.preferenceSetId = _defaultPreferenceSetId});
+}
+
+class PreferencesClient {
+  final Knock _knock;
+  final ApiClient _api;
+
+  PreferencesClient(this._knock, this._api);
+
+  Future<List<PreferenceSet>> getAll() async {
+    final response = await _api.doGet(
+      '/v1/users/${_knock.userId}/preferences',
+    );
+    final json = _decodeResponse(response) as List;
+    return json.map((e) => PreferenceSet.fromJson(e)).toList();
+  }
+
+  Future<PreferenceSet> get({
+    PreferenceOptions preferenceOptions = const PreferenceOptions(),
+  }) async {
+    final response = await _api.doGet(
+      '/v1/users/${_knock.userId}/preferences/${preferenceOptions.preferenceSetId}',
+    );
+    final json = _decodeResponse(response);
+    return PreferenceSet.fromJson(json);
+  }
+
+  Future<PreferenceSet> set(
+    SetPreferencesProperties setPreferencesProperties, {
+    PreferenceOptions preferenceOptions = const PreferenceOptions(),
+  }) async {
+    final body = jsonEncode(setPreferencesProperties.toJson());
+    final response = await _api.doPut(
+      '/v1/users/${_knock.userId}/preferences/${preferenceOptions.preferenceSetId}',
+      body: body,
+    );
+    final json = _decodeResponse(response);
+    return PreferenceSet.fromJson(json);
+  }
+
+  dynamic _decodeResponse(ApiResponse response) {
+    if (response.statusCode == StatusCode.error) {
+      throw Exception(response);
+    } else {
+      final body = response.body!;
+      return jsonDecode(body);
+    }
+  }
+}

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -10,11 +10,17 @@ environment:
 dependencies:
   flutter:
     sdk: flutter
+
   http: ^1.1.0
+  json_annotation: ^4.8.1
+  equatable: ^2.0.5
 
 dev_dependencies:
   flutter_test:
     sdk: flutter
   flutter_lints: ^2.0.0
+
+  build_runner:
+  json_serializable: ^6.7.1
 
 flutter:

--- a/test/src/api_client_test.dart
+++ b/test/src/api_client_test.dart
@@ -4,18 +4,21 @@ import 'package:knock_flutter/knock_flutter.dart';
 import 'package:http/testing.dart';
 
 import 'package:knock_flutter/src/api_client.dart';
+import 'package:knock_flutter/src/model/api_response.dart';
 
 void main() {
   group('ApiClient', () {
     late Knock knock;
+    late Response Function() responseBuilder;
     late ApiClient client;
     Request? capturedRequest;
 
     setUp(() {
       knock = Knock('public_api_key');
+      responseBuilder = () => Response("", 200);
       final mockClient = MockClient((request) async {
         capturedRequest = request;
-        return Response("", 200);
+        return responseBuilder();
       });
       client = ApiClient(knock, client: mockClient);
     });
@@ -25,38 +28,44 @@ void main() {
       client.dispose();
     });
 
-    test('correctly sets headers before user authentication', () async {
-      final uri = client.path('/users/1/preferences');
-      await client.get(uri);
+    test('correctly returns an ApiResponse when an exception occurs', () async {
+      final error = Error();
+      responseBuilder = () => throw error;
 
-      expect(capturedRequest?.headers['Accept'], 'application/json');
-      expect(capturedRequest?.headers['Content-Type'], 'application/json');
-      expect(capturedRequest?.headers['Authorization'], 'Bearer public_api_key');
-      expect(capturedRequest?.headers['X-Knock-User-Token'], null);
+      final response = await client.doGet('/');
+      expect(response, ApiResponse(status: 500, statusCode: StatusCode.error, error: error));
+    });
+
+    test('correctly sets headers before user authentication', () async {
+      await client.doGet('/');
+
+      final headers = capturedRequest?.headers ?? {};
+      expect(headers['Accept'], 'application/json');
+      expect(headers['Content-Type'], 'application/json');
+      expect(headers['Authorization'], 'Bearer public_api_key');
+      expect(headers['X-Knock-User-Token'], null);
     });
 
     test('correctly sets headers without enhanced security mode', () async {
       knock.authenticate('1');
+      await client.doGet('/');
 
-      final uri = client.path('/users/1/preferences');
-      await client.get(uri);
-
-      expect(capturedRequest?.headers['Accept'], 'application/json');
-      expect(capturedRequest?.headers['Content-Type'], 'application/json');
-      expect(capturedRequest?.headers['Authorization'], 'Bearer public_api_key');
-      expect(capturedRequest?.headers['X-Knock-User-Token'], null);
+      final headers = capturedRequest?.headers ?? {};
+      expect(headers['Accept'], 'application/json');
+      expect(headers['Content-Type'], 'application/json');
+      expect(headers['Authorization'], 'Bearer public_api_key');
+      expect(headers['X-Knock-User-Token'], null);
     });
 
     test('correctly sets headers with enhanced security mode', () async {
       knock.authenticate('1', 'test_jwt_token');
+      await client.doGet('/');
 
-      final uri = client.path('/users/1/preferences');
-      await client.get(uri);
-
-      expect(capturedRequest?.headers['Accept'], 'application/json');
-      expect(capturedRequest?.headers['Content-Type'], 'application/json');
-      expect(capturedRequest?.headers['Authorization'], 'Bearer public_api_key');
-      expect(capturedRequest?.headers['X-Knock-User-Token'], 'test_jwt_token');
+      final headers = capturedRequest?.headers ?? {};
+      expect(headers['Accept'], 'application/json');
+      expect(headers['Content-Type'], 'application/json');
+      expect(headers['Authorization'], 'Bearer public_api_key');
+      expect(headers['X-Knock-User-Token'], 'test_jwt_token');
     });
   });
 }

--- a/test/src/knock_test.dart
+++ b/test/src/knock_test.dart
@@ -45,5 +45,15 @@ void main() {
       expect(knock.userToken, isNull);
       expect(knock.isAuthenticated(checkUserToken: true), false);
     });
+
+    test('is required before using the client', () {
+      final knock = Knock("api_key");
+      expect(() => knock.client(), throwsStateError);
+    });
+
+    test('is required before using the preferences client', () {
+      final knock = Knock("api_key");
+      expect(() => knock.client(), throwsStateError);
+    });
   });
 }

--- a/test/src/model/preferences_test.dart
+++ b/test/src/model/preferences_test.dart
@@ -1,0 +1,198 @@
+import 'dart:convert';
+
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:knock_flutter/src/model/preferences.dart';
+
+void main() {
+  group('PreferenceSet deserializes', () {
+    test('correctly when no preference are used', () async {
+      final json = jsonDecode('''
+          {
+            "id": "default",
+            "channel_types": null,
+            "workflows": null,
+            "categories": null
+          }
+        ''');
+
+      final preferenceSet = PreferenceSet.fromJson(json);
+      expect(preferenceSet.id, 'default');
+      expect(preferenceSet.channelTypes, isNull);
+      expect(preferenceSet.workflows, isNull);
+      expect(preferenceSet.categories, isNull);
+    });
+
+    test('correctly when channel_types preference are used', () async {
+      final json = jsonDecode('''
+          {
+            "id": "default",
+            "channel_types": {
+              "in_app_feed": true,
+              "sms": true
+            },
+            "workflows": {
+              "dinosaurs-loose": {
+                "channel_types": {
+                  "email": true
+                }
+              }
+            },
+            "categories": {
+              "park-wide": {
+                "channel_types": {
+                  "sms": false
+                }
+              }
+            }
+          }
+        ''');
+
+      final preferenceSet = PreferenceSet.fromJson(json);
+      expect(preferenceSet.id, 'default');
+      expect(
+          preferenceSet.channelTypes,
+          equals({
+            ChannelType.sms: true,
+            ChannelType.inAppFeed: true,
+          }));
+      expect(
+          preferenceSet.workflows,
+          equals(
+            {
+              'dinosaurs-loose':
+                  WorkflowPreferenceSetting.channelTypePreferences(
+                const {ChannelType.email: true},
+              )
+            },
+          ));
+      expect(
+          preferenceSet.categories,
+          equals(
+            {
+              'park-wide': WorkflowPreferenceSetting.channelTypePreferences(
+                const {ChannelType.sms: false},
+              )
+            },
+          ));
+    });
+
+    test('correctly when boolean preferences are used', () async {
+      final json = jsonDecode('''
+          {
+            "id": "default",
+            "channel_types": {
+              "in_app_feed": true,
+              "sms": true
+            },
+            "workflows": {
+              "dinosaurs-loose": true
+            },
+            "categories": {
+              "park-wide": false
+            }
+          }
+        ''');
+
+      final preferenceSet = PreferenceSet.fromJson(json);
+      expect(preferenceSet.id, 'default');
+      expect(
+          preferenceSet.channelTypes,
+          equals({
+            ChannelType.sms: true,
+            ChannelType.inAppFeed: true,
+          }));
+      expect(
+        preferenceSet.workflows,
+        equals(
+          {'dinosaurs-loose': WorkflowPreferenceSetting.workflow(true)},
+        ),
+      );
+      expect(
+        preferenceSet.categories,
+        equals({'park-wide': WorkflowPreferenceSetting.workflow(false)}),
+      );
+    });
+  });
+
+  group('SetPreferencesProperties serializes', () {
+    test('correctly when no properties are used', () async {
+      expect(
+        const SetPreferencesProperties().toJson(),
+        {
+          'categories': null,
+          'workflows': null,
+          'channel_types': null,
+        },
+      );
+    });
+
+    test('correctly when boolean properties are used', () async {
+      expect(
+        SetPreferencesProperties(
+          categories: {
+            'park-wide': WorkflowPreferenceSetting.workflow(true),
+          },
+          workflows: {
+            'dinosaurs-loose': WorkflowPreferenceSetting.workflow(false),
+          },
+          channelTypes: const {
+            ChannelType.inAppFeed: true,
+          },
+        ).toJson(),
+        {
+          'categories': {
+            'park-wide': true,
+          },
+          'workflows': {
+            'dinosaurs-loose': false,
+          },
+          'channel_types': {
+            'in_app_feed': true,
+          },
+        },
+      );
+    });
+
+    test('correctly when channel_types properties are used', () async {
+      expect(
+        SetPreferencesProperties(
+          categories: {
+            'park-wide':
+                WorkflowPreferenceSetting.channelTypePreferences(const {
+              ChannelType.inAppFeed: true,
+            }),
+          },
+          workflows: {
+            'dinosaurs-loose':
+                WorkflowPreferenceSetting.channelTypePreferences(const {
+              ChannelType.inAppFeed: false,
+            }),
+          },
+          channelTypes: const {
+            ChannelType.inAppFeed: true,
+          },
+        ).toJson(),
+        {
+          'categories': {
+            'park-wide': {
+              'channel_types': {
+                'in_app_feed': true,
+              }
+            },
+          },
+          'workflows': {
+            'dinosaurs-loose': {
+              'channel_types': {
+                'in_app_feed': false,
+              }
+            }
+          },
+          'channel_types': {
+            'in_app_feed': true,
+          },
+        },
+      );
+    });
+  });
+}


### PR DESCRIPTION
- e`xample/lib/main.dart` - This is where you can start to see the surface area of the SDK.

- I'm not in love with these, but am trying to be descriptive for the user.
    - WorkflowPreferenceSetting.workflow
    - WorkflowPreferenceSetting.channelTypePreferences

There is a lot of extra code in `src/models/preferences.dart` around this type because heterogeneous fields in JSON with lots of simply typed languages are never pretty. The generated file (`preferences.g.dart`) can be skipped over for review. :-)

- I have the SDK throw a StateException if the user hasn't authenticated before making client calls. Is there anything the user can do that I haven't thought of yet that wouldn't require authentication first that would cause me to rethink this?