### PR TITLE
KNO-4772 feeds fetching

### DIFF
--- a/example/ios/Flutter/Debug.xcconfig
+++ b/example/ios/Flutter/Debug.xcconfig
@@ -1,1 +1,2 @@
+#include? "Pods/Target Support Files/Pods-Runner/Pods-Runner.debug.xcconfig"
 #include "Generated.xcconfig"

--- a/example/ios/Flutter/Release.xcconfig
+++ b/example/ios/Flutter/Release.xcconfig
@@ -1,1 +1,2 @@
+#include? "Pods/Target Support Files/Pods-Runner/Pods-Runner.release.xcconfig"
 #include "Generated.xcconfig"

--- a/example/ios/Podfile
+++ b/example/ios/Podfile
@@ -1,0 +1,44 @@
+# Uncomment this line to define a global platform for your project
+# platform :ios, '11.0'
+
+# CocoaPods analytics sends network stats synchronously affecting flutter build latency.
+ENV['COCOAPODS_DISABLE_STATS'] = 'true'
+
+project 'Runner', {
+  'Debug' => :debug,
+  'Profile' => :release,
+  'Release' => :release,
+}
+
+def flutter_root
+  generated_xcode_build_settings_path = File.expand_path(File.join('..', 'Flutter', 'Generated.xcconfig'), __FILE__)
+  unless File.exist?(generated_xcode_build_settings_path)
+    raise "#{generated_xcode_build_settings_path} must exist. If you're running pod install manually, make sure flutter pub get is executed first"
+  end
+
+  File.foreach(generated_xcode_build_settings_path) do |line|
+    matches = line.match(/FLUTTER_ROOT\=(.*)/)
+    return matches[1].strip if matches
+  end
+  raise "FLUTTER_ROOT not found in #{generated_xcode_build_settings_path}. Try deleting Generated.xcconfig, then run flutter pub get"
+end
+
+require File.expand_path(File.join('packages', 'flutter_tools', 'bin', 'podhelper'), flutter_root)
+
+flutter_ios_podfile_setup
+
+target 'Runner' do
+  use_frameworks!
+  use_modular_headers!
+
+  flutter_install_all_ios_pods File.dirname(File.realpath(__FILE__))
+  target 'RunnerTests' do
+    inherit! :search_paths
+  end
+end
+
+post_install do |installer|
+  installer.pods_project.targets.each do |target|
+    flutter_additional_ios_build_settings(target)
+  end
+end

--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -49,6 +49,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "3.0.3"
+  csslib:
+    dependency: transitive
+    description:
+      name: csslib
+      sha256: "831883fb353c8bdc1d71979e5b342c7d88acfbc643113c14ae51e2442ea0f20f"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.17.3"
   equatable:
     dependency: transitive
     description:
@@ -70,6 +78,14 @@ packages:
     description: flutter
     source: sdk
     version: "0.0.0"
+  flutter_html:
+    dependency: "direct main"
+    description:
+      name: flutter_html
+      sha256: "02ad69e813ecfc0728a455e4bf892b9379983e050722b1dce00192ee2e41d1ee"
+      url: "https://pub.dev"
+    source: hosted
+    version: "3.0.0-beta.2"
   flutter_lints:
     dependency: "direct dev"
     description:
@@ -91,6 +107,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.4.1"
+  html:
+    dependency: transitive
+    description:
+      name: html
+      sha256: "3a7812d5bcd2894edf53dfaf8cd640876cf6cef50a8f238745c8b8120ea74d3a"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.15.4"
   http:
     dependency: transitive
     description:
@@ -130,6 +154,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.1.1"
+  list_counter:
+    dependency: transitive
+    description:
+      name: list_counter
+      sha256: c447ae3dfcd1c55f0152867090e67e219d42fe6d4f2807db4bbe8b8d69912237
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.0.2"
   logging:
     dependency: transitive
     description:

--- a/example/pubspec.yaml
+++ b/example/pubspec.yaml
@@ -1,11 +1,11 @@
 name: knock_flutter_example
 description: Knock Flutter example app
-publish_to: 'none'
+publish_to: "none"
 
 version: 1.0.0+1
 
 environment:
-  sdk: '>=3.1.5 <4.0.0'
+  sdk: ">=3.1.5 <4.0.0"
 
 dependencies:
   flutter:
@@ -15,6 +15,8 @@ dependencies:
     # We reference the SDK in the parent directory for the example app.
     # In your app you will want to reference a released version.
     path: ..
+
+  flutter_html: 3.0.0-beta.2
 
 dev_dependencies:
   flutter_test:

--- a/lib/knock_flutter.dart
+++ b/lib/knock_flutter.dart
@@ -6,5 +6,6 @@ export 'src/preferences_client.dart';
 export 'src/feed_client.dart';
 export 'src/model/preferences.dart';
 export 'src/model/feed.dart';
+export 'src/model/feed_options.dart';
 export 'src/model/user.dart';
 export 'src/model/recipient.dart';

--- a/lib/src/api_client.dart
+++ b/lib/src/api_client.dart
@@ -55,16 +55,27 @@ class ApiClient extends http.BaseClient {
     return _client.send(request);
   }
 
-  Future<ApiResponse> doGet(String path) async {
-    return _doRequest(() => get(_usingPath(path)));
+  Future<ApiResponse> doGet(
+    String path, {
+    Map<String, dynamic>? queryParams,
+  }) async {
+    return _doRequest(() => get(_buildUri(path, queryParams)));
   }
 
-  Future<ApiResponse> doPut(String path, {Object? body}) async {
-    return _doRequest(() => put(_usingPath(path), body: body));
+  Future<ApiResponse> doPut(
+    String path, {
+    Map<String, dynamic>? queryParams,
+    Object? body,
+  }) async {
+    return _doRequest(() => put(_buildUri(path, queryParams), body: body));
   }
 
-  Future<ApiResponse> doPost(String path, {Object? body}) async {
-    return _doRequest(() => post(_usingPath(path), body: body));
+  Future<ApiResponse> doPost(
+    String path, {
+    Map<String, dynamic>? queryParams,
+    Object? body,
+  }) async {
+    return _doRequest(() => post(_buildUri(path, queryParams), body: body));
   }
 
   Future<ApiResponse> _doRequest(ApiRequestBuilder requestBuilder) async {
@@ -85,7 +96,21 @@ class ApiClient extends http.BaseClient {
     }
   }
 
-  Uri _usingPath(String path) => Uri.parse('$_host$path');
+  Uri _buildUri(String path, Map<String, dynamic>? queryParams) {
+    final uri = Uri.parse('$_host$path');
+    final cleanParams = Map<String, dynamic>.from(queryParams ?? {})
+        .map((key, value) => MapEntry(key, value?.toString()));
+    cleanParams.removeWhere((key, value) => value == null);
+
+    return Uri(
+        scheme: uri.scheme,
+        userInfo: uri.userInfo,
+        host: uri.host,
+        port: uri.port == 0 ? null : uri.port,
+        pathSegments: uri.pathSegments,
+        queryParameters: cleanParams,
+        fragment: uri.fragment);
+  }
 
   void dispose() {
     _client.close();

--- a/lib/src/knock.dart
+++ b/lib/src/knock.dart
@@ -84,7 +84,7 @@ class Knock {
 
   FeedClient feed(
     String feedChannelId, {
-    FeedOptions options = const FeedOptions(),
+    FeedOptions? options,
   }) {
     _assertAuthenticated();
     return FeedClient(this, client(), feedChannelId, options);

--- a/lib/src/model/feed.dart
+++ b/lib/src/model/feed.dart
@@ -1,5 +1,6 @@
 import 'package:freezed_annotation/freezed_annotation.dart';
 import 'package:knock_flutter/src/model/recipient.dart';
+import 'package:knock_flutter/src/util/date_time.dart';
 
 part 'feed.freezed.dart';
 part 'feed.g.dart';
@@ -51,6 +52,8 @@ enum BindableFeedEvent {
 
 @freezed
 class Feed with _$Feed {
+  const Feed._();
+
   factory Feed.initialState() {
     return const Feed(
       items: [],
@@ -74,21 +77,37 @@ class Feed with _$Feed {
   }) = _Feed;
 
   factory Feed.fromJson(Map<String, dynamic> json) => _$FeedFromJson(json);
+
+  bool get requestInFlight {
+    return networkStatus == NetworkStatus.loading ||
+        networkStatus == NetworkStatus.fetchMore;
+  }
 }
 
 @freezed
 class FeedItem with _$FeedItem {
   @JsonSerializable(explicitToJson: true)
   const factory FeedItem({
+    @JsonKey(name: '__cursor') required String knockInternalCursor,
     required String id,
     required List<Activity> activities,
     required List<Recipient> actors,
     required List<ContentBlock> blocks,
-    @JsonKey(name: 'inserted_at') required String insertedAt,
-    @JsonKey(name: 'updated_at') required String updatedAt,
-    @JsonKey(name: 'seen_at') required String? seenAt,
-    @JsonKey(name: 'read_at') required String? readAt,
-    @JsonKey(name: 'archived_at') required String? archivedAt,
+    @ISO8601DateTimeConverter()
+    @JsonKey(name: 'inserted_at')
+    required DateTime insertedAt,
+    @ISO8601DateTimeConverter()
+    @JsonKey(name: 'updated_at')
+    required DateTime updatedAt,
+    @ISO8601DateTimeConverter()
+    @JsonKey(name: 'seen_at')
+    required DateTime? seenAt,
+    @ISO8601DateTimeConverter()
+    @JsonKey(name: 'read_at')
+    required DateTime? readAt,
+    @ISO8601DateTimeConverter()
+    @JsonKey(name: 'archived_at')
+    required DateTime? archivedAt,
     @JsonKey(name: 'total_activities') required int totalActivities,
     @JsonKey(name: 'total_actors') required int totalActors,
     required Map<String, dynamic>? data,
@@ -105,8 +124,12 @@ class Activity with _$Activity {
   @JsonSerializable(explicitToJson: true)
   const factory Activity({
     required String id,
-    @JsonKey(name: 'inserted_at') required String insertedAt,
-    @JsonKey(name: 'updated_at') required String updatedAt,
+    @ISO8601DateTimeConverter()
+    @JsonKey(name: 'inserted_at')
+    required DateTime insertedAt,
+    @ISO8601DateTimeConverter()
+    @JsonKey(name: 'updated_at')
+    required DateTime updatedAt,
     required Recipient recipient,
     required Recipient? actor,
     required Map<String, dynamic>? data,

--- a/lib/src/model/feed.freezed.dart
+++ b/lib/src/model/feed.freezed.dart
@@ -164,14 +164,15 @@ class __$$FeedImplCopyWithImpl<$Res>
 /// @nodoc
 
 @JsonSerializable(explicitToJson: true)
-class _$FeedImpl implements _Feed {
+class _$FeedImpl extends _Feed {
   const _$FeedImpl(
       {@JsonKey(name: 'entries') required final List<FeedItem> items,
       @JsonKey(name: 'page_info') required this.pageInfo,
       @JsonKey(name: 'meta') required this.metadata,
       @JsonKey(includeFromJson: true, defaultValue: NetworkStatus.ready)
       required this.networkStatus})
-      : _items = items;
+      : _items = items,
+        super._();
 
   factory _$FeedImpl.fromJson(Map<String, dynamic> json) =>
       _$$FeedImplFromJson(json);
@@ -237,13 +238,14 @@ class _$FeedImpl implements _Feed {
   }
 }
 
-abstract class _Feed implements Feed {
+abstract class _Feed extends Feed {
   const factory _Feed(
       {@JsonKey(name: 'entries') required final List<FeedItem> items,
       @JsonKey(name: 'page_info') required final PageInfo pageInfo,
       @JsonKey(name: 'meta') required final FeedMetadata metadata,
       @JsonKey(includeFromJson: true, defaultValue: NetworkStatus.ready)
       required final NetworkStatus networkStatus}) = _$FeedImpl;
+  const _Feed._() : super._();
 
   factory _Feed.fromJson(Map<String, dynamic> json) = _$FeedImpl.fromJson;
 
@@ -271,20 +273,27 @@ FeedItem _$FeedItemFromJson(Map<String, dynamic> json) {
 
 /// @nodoc
 mixin _$FeedItem {
+  @JsonKey(name: '__cursor')
+  String get knockInternalCursor => throw _privateConstructorUsedError;
   String get id => throw _privateConstructorUsedError;
   List<Activity> get activities => throw _privateConstructorUsedError;
   List<Recipient> get actors => throw _privateConstructorUsedError;
   List<ContentBlock> get blocks => throw _privateConstructorUsedError;
+  @ISO8601DateTimeConverter()
   @JsonKey(name: 'inserted_at')
-  String get insertedAt => throw _privateConstructorUsedError;
+  DateTime get insertedAt => throw _privateConstructorUsedError;
+  @ISO8601DateTimeConverter()
   @JsonKey(name: 'updated_at')
-  String get updatedAt => throw _privateConstructorUsedError;
+  DateTime get updatedAt => throw _privateConstructorUsedError;
+  @ISO8601DateTimeConverter()
   @JsonKey(name: 'seen_at')
-  String? get seenAt => throw _privateConstructorUsedError;
+  DateTime? get seenAt => throw _privateConstructorUsedError;
+  @ISO8601DateTimeConverter()
   @JsonKey(name: 'read_at')
-  String? get readAt => throw _privateConstructorUsedError;
+  DateTime? get readAt => throw _privateConstructorUsedError;
+  @ISO8601DateTimeConverter()
   @JsonKey(name: 'archived_at')
-  String? get archivedAt => throw _privateConstructorUsedError;
+  DateTime? get archivedAt => throw _privateConstructorUsedError;
   @JsonKey(name: 'total_activities')
   int get totalActivities => throw _privateConstructorUsedError;
   @JsonKey(name: 'total_actors')
@@ -305,15 +314,22 @@ abstract class $FeedItemCopyWith<$Res> {
       _$FeedItemCopyWithImpl<$Res, FeedItem>;
   @useResult
   $Res call(
-      {String id,
+      {@JsonKey(name: '__cursor') String knockInternalCursor,
+      String id,
       List<Activity> activities,
       List<Recipient> actors,
       List<ContentBlock> blocks,
-      @JsonKey(name: 'inserted_at') String insertedAt,
-      @JsonKey(name: 'updated_at') String updatedAt,
-      @JsonKey(name: 'seen_at') String? seenAt,
-      @JsonKey(name: 'read_at') String? readAt,
-      @JsonKey(name: 'archived_at') String? archivedAt,
+      @ISO8601DateTimeConverter()
+      @JsonKey(name: 'inserted_at')
+      DateTime insertedAt,
+      @ISO8601DateTimeConverter()
+      @JsonKey(name: 'updated_at')
+      DateTime updatedAt,
+      @ISO8601DateTimeConverter() @JsonKey(name: 'seen_at') DateTime? seenAt,
+      @ISO8601DateTimeConverter() @JsonKey(name: 'read_at') DateTime? readAt,
+      @ISO8601DateTimeConverter()
+      @JsonKey(name: 'archived_at')
+      DateTime? archivedAt,
       @JsonKey(name: 'total_activities') int totalActivities,
       @JsonKey(name: 'total_actors') int totalActors,
       Map<String, dynamic>? data,
@@ -336,6 +352,7 @@ class _$FeedItemCopyWithImpl<$Res, $Val extends FeedItem>
   @pragma('vm:prefer-inline')
   @override
   $Res call({
+    Object? knockInternalCursor = null,
     Object? id = null,
     Object? activities = null,
     Object? actors = null,
@@ -352,6 +369,10 @@ class _$FeedItemCopyWithImpl<$Res, $Val extends FeedItem>
     Object? tenant = freezed,
   }) {
     return _then(_value.copyWith(
+      knockInternalCursor: null == knockInternalCursor
+          ? _value.knockInternalCursor
+          : knockInternalCursor // ignore: cast_nullable_to_non_nullable
+              as String,
       id: null == id
           ? _value.id
           : id // ignore: cast_nullable_to_non_nullable
@@ -371,23 +392,23 @@ class _$FeedItemCopyWithImpl<$Res, $Val extends FeedItem>
       insertedAt: null == insertedAt
           ? _value.insertedAt
           : insertedAt // ignore: cast_nullable_to_non_nullable
-              as String,
+              as DateTime,
       updatedAt: null == updatedAt
           ? _value.updatedAt
           : updatedAt // ignore: cast_nullable_to_non_nullable
-              as String,
+              as DateTime,
       seenAt: freezed == seenAt
           ? _value.seenAt
           : seenAt // ignore: cast_nullable_to_non_nullable
-              as String?,
+              as DateTime?,
       readAt: freezed == readAt
           ? _value.readAt
           : readAt // ignore: cast_nullable_to_non_nullable
-              as String?,
+              as DateTime?,
       archivedAt: freezed == archivedAt
           ? _value.archivedAt
           : archivedAt // ignore: cast_nullable_to_non_nullable
-              as String?,
+              as DateTime?,
       totalActivities: null == totalActivities
           ? _value.totalActivities
           : totalActivities // ignore: cast_nullable_to_non_nullable
@@ -429,15 +450,22 @@ abstract class _$$FeedItemImplCopyWith<$Res>
   @override
   @useResult
   $Res call(
-      {String id,
+      {@JsonKey(name: '__cursor') String knockInternalCursor,
+      String id,
       List<Activity> activities,
       List<Recipient> actors,
       List<ContentBlock> blocks,
-      @JsonKey(name: 'inserted_at') String insertedAt,
-      @JsonKey(name: 'updated_at') String updatedAt,
-      @JsonKey(name: 'seen_at') String? seenAt,
-      @JsonKey(name: 'read_at') String? readAt,
-      @JsonKey(name: 'archived_at') String? archivedAt,
+      @ISO8601DateTimeConverter()
+      @JsonKey(name: 'inserted_at')
+      DateTime insertedAt,
+      @ISO8601DateTimeConverter()
+      @JsonKey(name: 'updated_at')
+      DateTime updatedAt,
+      @ISO8601DateTimeConverter() @JsonKey(name: 'seen_at') DateTime? seenAt,
+      @ISO8601DateTimeConverter() @JsonKey(name: 'read_at') DateTime? readAt,
+      @ISO8601DateTimeConverter()
+      @JsonKey(name: 'archived_at')
+      DateTime? archivedAt,
       @JsonKey(name: 'total_activities') int totalActivities,
       @JsonKey(name: 'total_actors') int totalActors,
       Map<String, dynamic>? data,
@@ -459,6 +487,7 @@ class __$$FeedItemImplCopyWithImpl<$Res>
   @pragma('vm:prefer-inline')
   @override
   $Res call({
+    Object? knockInternalCursor = null,
     Object? id = null,
     Object? activities = null,
     Object? actors = null,
@@ -475,6 +504,10 @@ class __$$FeedItemImplCopyWithImpl<$Res>
     Object? tenant = freezed,
   }) {
     return _then(_$FeedItemImpl(
+      knockInternalCursor: null == knockInternalCursor
+          ? _value.knockInternalCursor
+          : knockInternalCursor // ignore: cast_nullable_to_non_nullable
+              as String,
       id: null == id
           ? _value.id
           : id // ignore: cast_nullable_to_non_nullable
@@ -494,23 +527,23 @@ class __$$FeedItemImplCopyWithImpl<$Res>
       insertedAt: null == insertedAt
           ? _value.insertedAt
           : insertedAt // ignore: cast_nullable_to_non_nullable
-              as String,
+              as DateTime,
       updatedAt: null == updatedAt
           ? _value.updatedAt
           : updatedAt // ignore: cast_nullable_to_non_nullable
-              as String,
+              as DateTime,
       seenAt: freezed == seenAt
           ? _value.seenAt
           : seenAt // ignore: cast_nullable_to_non_nullable
-              as String?,
+              as DateTime?,
       readAt: freezed == readAt
           ? _value.readAt
           : readAt // ignore: cast_nullable_to_non_nullable
-              as String?,
+              as DateTime?,
       archivedAt: freezed == archivedAt
           ? _value.archivedAt
           : archivedAt // ignore: cast_nullable_to_non_nullable
-              as String?,
+              as DateTime?,
       totalActivities: null == totalActivities
           ? _value.totalActivities
           : totalActivities // ignore: cast_nullable_to_non_nullable
@@ -540,15 +573,26 @@ class __$$FeedItemImplCopyWithImpl<$Res>
 @JsonSerializable(explicitToJson: true)
 class _$FeedItemImpl implements _FeedItem {
   const _$FeedItemImpl(
-      {required this.id,
+      {@JsonKey(name: '__cursor') required this.knockInternalCursor,
+      required this.id,
       required final List<Activity> activities,
       required final List<Recipient> actors,
       required final List<ContentBlock> blocks,
-      @JsonKey(name: 'inserted_at') required this.insertedAt,
-      @JsonKey(name: 'updated_at') required this.updatedAt,
-      @JsonKey(name: 'seen_at') required this.seenAt,
-      @JsonKey(name: 'read_at') required this.readAt,
-      @JsonKey(name: 'archived_at') required this.archivedAt,
+      @ISO8601DateTimeConverter()
+      @JsonKey(name: 'inserted_at')
+      required this.insertedAt,
+      @ISO8601DateTimeConverter()
+      @JsonKey(name: 'updated_at')
+      required this.updatedAt,
+      @ISO8601DateTimeConverter()
+      @JsonKey(name: 'seen_at')
+      required this.seenAt,
+      @ISO8601DateTimeConverter()
+      @JsonKey(name: 'read_at')
+      required this.readAt,
+      @ISO8601DateTimeConverter()
+      @JsonKey(name: 'archived_at')
+      required this.archivedAt,
       @JsonKey(name: 'total_activities') required this.totalActivities,
       @JsonKey(name: 'total_actors') required this.totalActors,
       required final Map<String, dynamic>? data,
@@ -562,6 +606,9 @@ class _$FeedItemImpl implements _FeedItem {
   factory _$FeedItemImpl.fromJson(Map<String, dynamic> json) =>
       _$$FeedItemImplFromJson(json);
 
+  @override
+  @JsonKey(name: '__cursor')
+  final String knockInternalCursor;
   @override
   final String id;
   final List<Activity> _activities;
@@ -589,20 +636,25 @@ class _$FeedItemImpl implements _FeedItem {
   }
 
   @override
+  @ISO8601DateTimeConverter()
   @JsonKey(name: 'inserted_at')
-  final String insertedAt;
+  final DateTime insertedAt;
   @override
+  @ISO8601DateTimeConverter()
   @JsonKey(name: 'updated_at')
-  final String updatedAt;
+  final DateTime updatedAt;
   @override
+  @ISO8601DateTimeConverter()
   @JsonKey(name: 'seen_at')
-  final String? seenAt;
+  final DateTime? seenAt;
   @override
+  @ISO8601DateTimeConverter()
   @JsonKey(name: 'read_at')
-  final String? readAt;
+  final DateTime? readAt;
   @override
+  @ISO8601DateTimeConverter()
   @JsonKey(name: 'archived_at')
-  final String? archivedAt;
+  final DateTime? archivedAt;
   @override
   @JsonKey(name: 'total_activities')
   final int totalActivities;
@@ -626,7 +678,7 @@ class _$FeedItemImpl implements _FeedItem {
 
   @override
   String toString() {
-    return 'FeedItem(id: $id, activities: $activities, actors: $actors, blocks: $blocks, insertedAt: $insertedAt, updatedAt: $updatedAt, seenAt: $seenAt, readAt: $readAt, archivedAt: $archivedAt, totalActivities: $totalActivities, totalActors: $totalActors, data: $data, source: $source, tenant: $tenant)';
+    return 'FeedItem(knockInternalCursor: $knockInternalCursor, id: $id, activities: $activities, actors: $actors, blocks: $blocks, insertedAt: $insertedAt, updatedAt: $updatedAt, seenAt: $seenAt, readAt: $readAt, archivedAt: $archivedAt, totalActivities: $totalActivities, totalActors: $totalActors, data: $data, source: $source, tenant: $tenant)';
   }
 
   @override
@@ -634,6 +686,8 @@ class _$FeedItemImpl implements _FeedItem {
     return identical(this, other) ||
         (other.runtimeType == runtimeType &&
             other is _$FeedItemImpl &&
+            (identical(other.knockInternalCursor, knockInternalCursor) ||
+                other.knockInternalCursor == knockInternalCursor) &&
             (identical(other.id, id) || other.id == id) &&
             const DeepCollectionEquality()
                 .equals(other._activities, _activities) &&
@@ -660,6 +714,7 @@ class _$FeedItemImpl implements _FeedItem {
   @override
   int get hashCode => Object.hash(
       runtimeType,
+      knockInternalCursor,
       id,
       const DeepCollectionEquality().hash(_activities),
       const DeepCollectionEquality().hash(_actors),
@@ -691,15 +746,26 @@ class _$FeedItemImpl implements _FeedItem {
 
 abstract class _FeedItem implements FeedItem {
   const factory _FeedItem(
-      {required final String id,
+      {@JsonKey(name: '__cursor') required final String knockInternalCursor,
+      required final String id,
       required final List<Activity> activities,
       required final List<Recipient> actors,
       required final List<ContentBlock> blocks,
-      @JsonKey(name: 'inserted_at') required final String insertedAt,
-      @JsonKey(name: 'updated_at') required final String updatedAt,
-      @JsonKey(name: 'seen_at') required final String? seenAt,
-      @JsonKey(name: 'read_at') required final String? readAt,
-      @JsonKey(name: 'archived_at') required final String? archivedAt,
+      @ISO8601DateTimeConverter()
+      @JsonKey(name: 'inserted_at')
+      required final DateTime insertedAt,
+      @ISO8601DateTimeConverter()
+      @JsonKey(name: 'updated_at')
+      required final DateTime updatedAt,
+      @ISO8601DateTimeConverter()
+      @JsonKey(name: 'seen_at')
+      required final DateTime? seenAt,
+      @ISO8601DateTimeConverter()
+      @JsonKey(name: 'read_at')
+      required final DateTime? readAt,
+      @ISO8601DateTimeConverter()
+      @JsonKey(name: 'archived_at')
+      required final DateTime? archivedAt,
       @JsonKey(name: 'total_activities') required final int totalActivities,
       @JsonKey(name: 'total_actors') required final int totalActors,
       required final Map<String, dynamic>? data,
@@ -710,6 +776,9 @@ abstract class _FeedItem implements FeedItem {
       _$FeedItemImpl.fromJson;
 
   @override
+  @JsonKey(name: '__cursor')
+  String get knockInternalCursor;
+  @override
   String get id;
   @override
   List<Activity> get activities;
@@ -718,20 +787,25 @@ abstract class _FeedItem implements FeedItem {
   @override
   List<ContentBlock> get blocks;
   @override
+  @ISO8601DateTimeConverter()
   @JsonKey(name: 'inserted_at')
-  String get insertedAt;
+  DateTime get insertedAt;
   @override
+  @ISO8601DateTimeConverter()
   @JsonKey(name: 'updated_at')
-  String get updatedAt;
+  DateTime get updatedAt;
   @override
+  @ISO8601DateTimeConverter()
   @JsonKey(name: 'seen_at')
-  String? get seenAt;
+  DateTime? get seenAt;
   @override
+  @ISO8601DateTimeConverter()
   @JsonKey(name: 'read_at')
-  String? get readAt;
+  DateTime? get readAt;
   @override
+  @ISO8601DateTimeConverter()
   @JsonKey(name: 'archived_at')
-  String? get archivedAt;
+  DateTime? get archivedAt;
   @override
   @JsonKey(name: 'total_activities')
   int get totalActivities;
@@ -757,10 +831,12 @@ Activity _$ActivityFromJson(Map<String, dynamic> json) {
 /// @nodoc
 mixin _$Activity {
   String get id => throw _privateConstructorUsedError;
+  @ISO8601DateTimeConverter()
   @JsonKey(name: 'inserted_at')
-  String get insertedAt => throw _privateConstructorUsedError;
+  DateTime get insertedAt => throw _privateConstructorUsedError;
+  @ISO8601DateTimeConverter()
   @JsonKey(name: 'updated_at')
-  String get updatedAt => throw _privateConstructorUsedError;
+  DateTime get updatedAt => throw _privateConstructorUsedError;
   Recipient get recipient => throw _privateConstructorUsedError;
   Recipient? get actor => throw _privateConstructorUsedError;
   Map<String, dynamic>? get data => throw _privateConstructorUsedError;
@@ -778,8 +854,12 @@ abstract class $ActivityCopyWith<$Res> {
   @useResult
   $Res call(
       {String id,
-      @JsonKey(name: 'inserted_at') String insertedAt,
-      @JsonKey(name: 'updated_at') String updatedAt,
+      @ISO8601DateTimeConverter()
+      @JsonKey(name: 'inserted_at')
+      DateTime insertedAt,
+      @ISO8601DateTimeConverter()
+      @JsonKey(name: 'updated_at')
+      DateTime updatedAt,
       Recipient recipient,
       Recipient? actor,
       Map<String, dynamic>? data});
@@ -816,11 +896,11 @@ class _$ActivityCopyWithImpl<$Res, $Val extends Activity>
       insertedAt: null == insertedAt
           ? _value.insertedAt
           : insertedAt // ignore: cast_nullable_to_non_nullable
-              as String,
+              as DateTime,
       updatedAt: null == updatedAt
           ? _value.updatedAt
           : updatedAt // ignore: cast_nullable_to_non_nullable
-              as String,
+              as DateTime,
       recipient: null == recipient
           ? _value.recipient
           : recipient // ignore: cast_nullable_to_non_nullable
@@ -867,8 +947,12 @@ abstract class _$$ActivityImplCopyWith<$Res>
   @useResult
   $Res call(
       {String id,
-      @JsonKey(name: 'inserted_at') String insertedAt,
-      @JsonKey(name: 'updated_at') String updatedAt,
+      @ISO8601DateTimeConverter()
+      @JsonKey(name: 'inserted_at')
+      DateTime insertedAt,
+      @ISO8601DateTimeConverter()
+      @JsonKey(name: 'updated_at')
+      DateTime updatedAt,
       Recipient recipient,
       Recipient? actor,
       Map<String, dynamic>? data});
@@ -905,11 +989,11 @@ class __$$ActivityImplCopyWithImpl<$Res>
       insertedAt: null == insertedAt
           ? _value.insertedAt
           : insertedAt // ignore: cast_nullable_to_non_nullable
-              as String,
+              as DateTime,
       updatedAt: null == updatedAt
           ? _value.updatedAt
           : updatedAt // ignore: cast_nullable_to_non_nullable
-              as String,
+              as DateTime,
       recipient: null == recipient
           ? _value.recipient
           : recipient // ignore: cast_nullable_to_non_nullable
@@ -932,8 +1016,12 @@ class __$$ActivityImplCopyWithImpl<$Res>
 class _$ActivityImpl implements _Activity {
   const _$ActivityImpl(
       {required this.id,
-      @JsonKey(name: 'inserted_at') required this.insertedAt,
-      @JsonKey(name: 'updated_at') required this.updatedAt,
+      @ISO8601DateTimeConverter()
+      @JsonKey(name: 'inserted_at')
+      required this.insertedAt,
+      @ISO8601DateTimeConverter()
+      @JsonKey(name: 'updated_at')
+      required this.updatedAt,
       required this.recipient,
       required this.actor,
       required final Map<String, dynamic>? data})
@@ -945,11 +1033,13 @@ class _$ActivityImpl implements _Activity {
   @override
   final String id;
   @override
+  @ISO8601DateTimeConverter()
   @JsonKey(name: 'inserted_at')
-  final String insertedAt;
+  final DateTime insertedAt;
   @override
+  @ISO8601DateTimeConverter()
   @JsonKey(name: 'updated_at')
-  final String updatedAt;
+  final DateTime updatedAt;
   @override
   final Recipient recipient;
   @override
@@ -1007,8 +1097,12 @@ class _$ActivityImpl implements _Activity {
 abstract class _Activity implements Activity {
   const factory _Activity(
       {required final String id,
-      @JsonKey(name: 'inserted_at') required final String insertedAt,
-      @JsonKey(name: 'updated_at') required final String updatedAt,
+      @ISO8601DateTimeConverter()
+      @JsonKey(name: 'inserted_at')
+      required final DateTime insertedAt,
+      @ISO8601DateTimeConverter()
+      @JsonKey(name: 'updated_at')
+      required final DateTime updatedAt,
       required final Recipient recipient,
       required final Recipient? actor,
       required final Map<String, dynamic>? data}) = _$ActivityImpl;
@@ -1019,11 +1113,13 @@ abstract class _Activity implements Activity {
   @override
   String get id;
   @override
+  @ISO8601DateTimeConverter()
   @JsonKey(name: 'inserted_at')
-  String get insertedAt;
+  DateTime get insertedAt;
   @override
+  @ISO8601DateTimeConverter()
   @JsonKey(name: 'updated_at')
-  String get updatedAt;
+  DateTime get updatedAt;
   @override
   Recipient get recipient;
   @override

--- a/lib/src/model/feed.g.dart
+++ b/lib/src/model/feed.g.dart
@@ -36,6 +36,7 @@ const _$NetworkStatusEnumMap = {
 
 _$FeedItemImpl _$$FeedItemImplFromJson(Map<String, dynamic> json) =>
     _$FeedItemImpl(
+      knockInternalCursor: json['__cursor'] as String,
       id: json['id'] as String,
       activities: (json['activities'] as List<dynamic>)
           .map((e) => Activity.fromJson(e as Map<String, dynamic>))
@@ -46,11 +47,16 @@ _$FeedItemImpl _$$FeedItemImplFromJson(Map<String, dynamic> json) =>
       blocks: (json['blocks'] as List<dynamic>)
           .map((e) => ContentBlock.fromJson(e as Map<String, dynamic>))
           .toList(),
-      insertedAt: json['inserted_at'] as String,
-      updatedAt: json['updated_at'] as String,
-      seenAt: json['seen_at'] as String?,
-      readAt: json['read_at'] as String?,
-      archivedAt: json['archived_at'] as String?,
+      insertedAt: const ISO8601DateTimeConverter()
+          .fromJson(json['inserted_at'] as String),
+      updatedAt: const ISO8601DateTimeConverter()
+          .fromJson(json['updated_at'] as String),
+      seenAt: _$JsonConverterFromJson<String, DateTime>(
+          json['seen_at'], const ISO8601DateTimeConverter().fromJson),
+      readAt: _$JsonConverterFromJson<String, DateTime>(
+          json['read_at'], const ISO8601DateTimeConverter().fromJson),
+      archivedAt: _$JsonConverterFromJson<String, DateTime>(
+          json['archived_at'], const ISO8601DateTimeConverter().fromJson),
       totalActivities: json['total_activities'] as int,
       totalActors: json['total_actors'] as int,
       data: json['data'] as Map<String, dynamic>?,
@@ -61,15 +67,20 @@ _$FeedItemImpl _$$FeedItemImplFromJson(Map<String, dynamic> json) =>
 
 Map<String, dynamic> _$$FeedItemImplToJson(_$FeedItemImpl instance) =>
     <String, dynamic>{
+      '__cursor': instance.knockInternalCursor,
       'id': instance.id,
       'activities': instance.activities.map((e) => e.toJson()).toList(),
       'actors': instance.actors.map((e) => e.toJson()).toList(),
       'blocks': instance.blocks.map((e) => e.toJson()).toList(),
-      'inserted_at': instance.insertedAt,
-      'updated_at': instance.updatedAt,
-      'seen_at': instance.seenAt,
-      'read_at': instance.readAt,
-      'archived_at': instance.archivedAt,
+      'inserted_at':
+          const ISO8601DateTimeConverter().toJson(instance.insertedAt),
+      'updated_at': const ISO8601DateTimeConverter().toJson(instance.updatedAt),
+      'seen_at': _$JsonConverterToJson<String, DateTime>(
+          instance.seenAt, const ISO8601DateTimeConverter().toJson),
+      'read_at': _$JsonConverterToJson<String, DateTime>(
+          instance.readAt, const ISO8601DateTimeConverter().toJson),
+      'archived_at': _$JsonConverterToJson<String, DateTime>(
+          instance.archivedAt, const ISO8601DateTimeConverter().toJson),
       'total_activities': instance.totalActivities,
       'total_actors': instance.totalActors,
       'data': instance.data,
@@ -77,11 +88,25 @@ Map<String, dynamic> _$$FeedItemImplToJson(_$FeedItemImpl instance) =>
       'tenant': instance.tenant,
     };
 
+Value? _$JsonConverterFromJson<Json, Value>(
+  Object? json,
+  Value? Function(Json json) fromJson,
+) =>
+    json == null ? null : fromJson(json as Json);
+
+Json? _$JsonConverterToJson<Json, Value>(
+  Value? value,
+  Json? Function(Value value) toJson,
+) =>
+    value == null ? null : toJson(value);
+
 _$ActivityImpl _$$ActivityImplFromJson(Map<String, dynamic> json) =>
     _$ActivityImpl(
       id: json['id'] as String,
-      insertedAt: json['inserted_at'] as String,
-      updatedAt: json['updated_at'] as String,
+      insertedAt: const ISO8601DateTimeConverter()
+          .fromJson(json['inserted_at'] as String),
+      updatedAt: const ISO8601DateTimeConverter()
+          .fromJson(json['updated_at'] as String),
       recipient: Recipient.fromJson(json['recipient'] as Map<String, dynamic>),
       actor: json['actor'] == null
           ? null
@@ -92,8 +117,9 @@ _$ActivityImpl _$$ActivityImplFromJson(Map<String, dynamic> json) =>
 Map<String, dynamic> _$$ActivityImplToJson(_$ActivityImpl instance) =>
     <String, dynamic>{
       'id': instance.id,
-      'inserted_at': instance.insertedAt,
-      'updated_at': instance.updatedAt,
+      'inserted_at':
+          const ISO8601DateTimeConverter().toJson(instance.insertedAt),
+      'updated_at': const ISO8601DateTimeConverter().toJson(instance.updatedAt),
       'recipient': instance.recipient.toJson(),
       'actor': instance.actor?.toJson(),
       'data': instance.data,

--- a/lib/src/model/feed_extensions.dart
+++ b/lib/src/model/feed_extensions.dart
@@ -1,7 +1,6 @@
 // This file is not intended for export in the public interface.
 
 import 'package:knock_flutter/knock_flutter.dart';
-import 'package:knock_flutter/src/util/date_time_extension.dart';
 
 extension FeedItemsModifiers on Iterable<FeedItem> {
   void action(Function(List<String> ids) callback) {
@@ -31,60 +30,95 @@ extension FeedModifiersExtension on Feed {
   Feed markAsSeen(Iterable<String> ids, DateTime at) {
     return copyWith(
       items: items._filteredMap(ids, (item) {
-        return item.copyWith(
-          seenAt: at.apiFormatted(),
-        );
+        return item.copyWith(seenAt: at);
       }),
+      // TODO KNO-4771 optimistic updates (metadata)
     );
   }
 
   Feed markAsUnseen(Iterable<String> ids) {
     return copyWith(
       items: items._filteredMap(ids, (item) {
-        return item.copyWith(
-          seenAt: null,
-        );
+        return item.copyWith(seenAt: null);
       }),
+      // TODO KNO-4771 optimistic updates (metadata)
     );
   }
 
   Feed markAsRead(Iterable<String> ids, DateTime at) {
     return copyWith(
       items: items._filteredMap(ids, (item) {
-        return item.copyWith(
-          readAt: at.apiFormatted(),
-        );
+        return item.copyWith(readAt: at);
       }),
+      // TODO KNO-4771 optimistic updates (metadata)
     );
   }
 
   Feed markAsUnread(Iterable<String> ids) {
     return copyWith(
       items: items._filteredMap(ids, (item) {
-        return item.copyWith(
-          readAt: null,
-        );
+        return item.copyWith(readAt: null);
       }),
+      // TODO KNO-4771 optimistic updates (metadata)
     );
   }
 
   Feed markAsArchived(Iterable<String> ids, DateTime at) {
     return copyWith(
       items: items._filteredMap(ids, (item) {
-        return item.copyWith(
-          archivedAt: at.apiFormatted(),
-        );
+        return item.copyWith(archivedAt: at);
       }),
+      // TODO KNO-4771 optimistic updates (metadata)
     );
   }
 
   Feed markAsUnarchived(Iterable<String> ids) {
     return copyWith(
       items: items._filteredMap(ids, (item) {
-        return item.copyWith(
-          archivedAt: null,
-        );
+        return item.copyWith(archivedAt: null);
       }),
+      // TODO KNO-4771 optimistic updates (metadata)
+    );
+  }
+
+  Feed markAllAsSeen(DateTime timestamp) {
+    // TODO KNO-4771 optimistic updates
+    return this;
+  }
+
+  Feed markAllAsRead(DateTime timestamp) {
+    // TODO KNO-4771 optimistic updates
+    return this;
+  }
+
+  Feed markAllAsArchived(DateTime timestamp) {
+    // TODO KNO-4771 optimistic updates
+    return this;
+  }
+
+  Feed merge(
+    Feed other, {
+    bool shouldSetPage = true,
+    bool shouldAppend = false,
+  }) {
+    final List<FeedItem> mergedItems;
+    if (shouldAppend) {
+      // Prioritize the incoming feed because it is most likely more up to date
+      mergedItems = other.items + items;
+
+      final Set<String> ids = {};
+      mergedItems.retainWhere((item) => ids.add(item.id));
+    } else {
+      mergedItems = List.from(other.items);
+    }
+
+    mergedItems.sort((a, b) => -1 * a.insertedAt.compareTo(b.insertedAt));
+
+    return Feed(
+      items: mergedItems,
+      pageInfo: shouldSetPage ? other.pageInfo : pageInfo,
+      metadata: other.metadata,
+      networkStatus: networkStatus,
     );
   }
 }

--- a/lib/src/model/feed_options.dart
+++ b/lib/src/model/feed_options.dart
@@ -1,0 +1,41 @@
+import 'package:freezed_annotation/freezed_annotation.dart';
+
+part 'feed_options.freezed.dart';
+part 'feed_options.g.dart';
+
+enum FeedOptionsStatus {
+  unread,
+  read,
+  unseen,
+  seen,
+  all;
+}
+
+enum FeedOptionsArchivedScope {
+  include,
+  exclude,
+  only;
+}
+
+@Freezed(toJson: true)
+class FeedOptions with _$FeedOptions {
+  factory FeedOptions.defaultOptions() {
+    return const FeedOptions(
+      archived: FeedOptionsArchivedScope.exclude,
+    );
+  }
+
+  @JsonSerializable(explicitToJson: true)
+  const factory FeedOptions({
+    String? before,
+    String? after,
+    @JsonKey(name: 'page_size') int? pageSize,
+    FeedOptionsStatus? status,
+    String? source,
+    String? tenant,
+    @JsonKey(name: 'has_tenant') bool? hasTenant,
+    @Default(FeedOptionsArchivedScope.exclude)
+    FeedOptionsArchivedScope archived,
+    Map<String, dynamic>? triggerData,
+  }) = _FeedOptions;
+}

--- a/lib/src/model/feed_options.freezed.dart
+++ b/lib/src/model/feed_options.freezed.dart
@@ -1,0 +1,335 @@
+// coverage:ignore-file
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// ignore_for_file: type=lint
+// ignore_for_file: unused_element, deprecated_member_use, deprecated_member_use_from_same_package, use_function_type_syntax_for_parameters, unnecessary_const, avoid_init_to_null, invalid_override_different_default_values_named, prefer_expression_function_bodies, annotate_overrides, invalid_annotation_target, unnecessary_question_mark
+
+part of 'feed_options.dart';
+
+// **************************************************************************
+// FreezedGenerator
+// **************************************************************************
+
+T _$identity<T>(T value) => value;
+
+final _privateConstructorUsedError = UnsupportedError(
+    'It seems like you constructed your class using `MyClass._()`. This constructor is only meant to be used by freezed and you are not supposed to need it nor use it.\nPlease check the documentation here for more information: https://github.com/rrousselGit/freezed#custom-getters-and-methods');
+
+/// @nodoc
+mixin _$FeedOptions {
+  String? get before => throw _privateConstructorUsedError;
+  String? get after => throw _privateConstructorUsedError;
+  @JsonKey(name: 'page_size')
+  int? get pageSize => throw _privateConstructorUsedError;
+  FeedOptionsStatus? get status => throw _privateConstructorUsedError;
+  String? get source => throw _privateConstructorUsedError;
+  String? get tenant => throw _privateConstructorUsedError;
+  @JsonKey(name: 'has_tenant')
+  bool? get hasTenant => throw _privateConstructorUsedError;
+  FeedOptionsArchivedScope get archived => throw _privateConstructorUsedError;
+  Map<String, dynamic>? get triggerData => throw _privateConstructorUsedError;
+
+  Map<String, dynamic> toJson() => throw _privateConstructorUsedError;
+  @JsonKey(ignore: true)
+  $FeedOptionsCopyWith<FeedOptions> get copyWith =>
+      throw _privateConstructorUsedError;
+}
+
+/// @nodoc
+abstract class $FeedOptionsCopyWith<$Res> {
+  factory $FeedOptionsCopyWith(
+          FeedOptions value, $Res Function(FeedOptions) then) =
+      _$FeedOptionsCopyWithImpl<$Res, FeedOptions>;
+  @useResult
+  $Res call(
+      {String? before,
+      String? after,
+      @JsonKey(name: 'page_size') int? pageSize,
+      FeedOptionsStatus? status,
+      String? source,
+      String? tenant,
+      @JsonKey(name: 'has_tenant') bool? hasTenant,
+      FeedOptionsArchivedScope archived,
+      Map<String, dynamic>? triggerData});
+}
+
+/// @nodoc
+class _$FeedOptionsCopyWithImpl<$Res, $Val extends FeedOptions>
+    implements $FeedOptionsCopyWith<$Res> {
+  _$FeedOptionsCopyWithImpl(this._value, this._then);
+
+  // ignore: unused_field
+  final $Val _value;
+  // ignore: unused_field
+  final $Res Function($Val) _then;
+
+  @pragma('vm:prefer-inline')
+  @override
+  $Res call({
+    Object? before = freezed,
+    Object? after = freezed,
+    Object? pageSize = freezed,
+    Object? status = freezed,
+    Object? source = freezed,
+    Object? tenant = freezed,
+    Object? hasTenant = freezed,
+    Object? archived = null,
+    Object? triggerData = freezed,
+  }) {
+    return _then(_value.copyWith(
+      before: freezed == before
+          ? _value.before
+          : before // ignore: cast_nullable_to_non_nullable
+              as String?,
+      after: freezed == after
+          ? _value.after
+          : after // ignore: cast_nullable_to_non_nullable
+              as String?,
+      pageSize: freezed == pageSize
+          ? _value.pageSize
+          : pageSize // ignore: cast_nullable_to_non_nullable
+              as int?,
+      status: freezed == status
+          ? _value.status
+          : status // ignore: cast_nullable_to_non_nullable
+              as FeedOptionsStatus?,
+      source: freezed == source
+          ? _value.source
+          : source // ignore: cast_nullable_to_non_nullable
+              as String?,
+      tenant: freezed == tenant
+          ? _value.tenant
+          : tenant // ignore: cast_nullable_to_non_nullable
+              as String?,
+      hasTenant: freezed == hasTenant
+          ? _value.hasTenant
+          : hasTenant // ignore: cast_nullable_to_non_nullable
+              as bool?,
+      archived: null == archived
+          ? _value.archived
+          : archived // ignore: cast_nullable_to_non_nullable
+              as FeedOptionsArchivedScope,
+      triggerData: freezed == triggerData
+          ? _value.triggerData
+          : triggerData // ignore: cast_nullable_to_non_nullable
+              as Map<String, dynamic>?,
+    ) as $Val);
+  }
+}
+
+/// @nodoc
+abstract class _$$FeedOptionsImplCopyWith<$Res>
+    implements $FeedOptionsCopyWith<$Res> {
+  factory _$$FeedOptionsImplCopyWith(
+          _$FeedOptionsImpl value, $Res Function(_$FeedOptionsImpl) then) =
+      __$$FeedOptionsImplCopyWithImpl<$Res>;
+  @override
+  @useResult
+  $Res call(
+      {String? before,
+      String? after,
+      @JsonKey(name: 'page_size') int? pageSize,
+      FeedOptionsStatus? status,
+      String? source,
+      String? tenant,
+      @JsonKey(name: 'has_tenant') bool? hasTenant,
+      FeedOptionsArchivedScope archived,
+      Map<String, dynamic>? triggerData});
+}
+
+/// @nodoc
+class __$$FeedOptionsImplCopyWithImpl<$Res>
+    extends _$FeedOptionsCopyWithImpl<$Res, _$FeedOptionsImpl>
+    implements _$$FeedOptionsImplCopyWith<$Res> {
+  __$$FeedOptionsImplCopyWithImpl(
+      _$FeedOptionsImpl _value, $Res Function(_$FeedOptionsImpl) _then)
+      : super(_value, _then);
+
+  @pragma('vm:prefer-inline')
+  @override
+  $Res call({
+    Object? before = freezed,
+    Object? after = freezed,
+    Object? pageSize = freezed,
+    Object? status = freezed,
+    Object? source = freezed,
+    Object? tenant = freezed,
+    Object? hasTenant = freezed,
+    Object? archived = null,
+    Object? triggerData = freezed,
+  }) {
+    return _then(_$FeedOptionsImpl(
+      before: freezed == before
+          ? _value.before
+          : before // ignore: cast_nullable_to_non_nullable
+              as String?,
+      after: freezed == after
+          ? _value.after
+          : after // ignore: cast_nullable_to_non_nullable
+              as String?,
+      pageSize: freezed == pageSize
+          ? _value.pageSize
+          : pageSize // ignore: cast_nullable_to_non_nullable
+              as int?,
+      status: freezed == status
+          ? _value.status
+          : status // ignore: cast_nullable_to_non_nullable
+              as FeedOptionsStatus?,
+      source: freezed == source
+          ? _value.source
+          : source // ignore: cast_nullable_to_non_nullable
+              as String?,
+      tenant: freezed == tenant
+          ? _value.tenant
+          : tenant // ignore: cast_nullable_to_non_nullable
+              as String?,
+      hasTenant: freezed == hasTenant
+          ? _value.hasTenant
+          : hasTenant // ignore: cast_nullable_to_non_nullable
+              as bool?,
+      archived: null == archived
+          ? _value.archived
+          : archived // ignore: cast_nullable_to_non_nullable
+              as FeedOptionsArchivedScope,
+      triggerData: freezed == triggerData
+          ? _value._triggerData
+          : triggerData // ignore: cast_nullable_to_non_nullable
+              as Map<String, dynamic>?,
+    ));
+  }
+}
+
+/// @nodoc
+
+@JsonSerializable(explicitToJson: true)
+class _$FeedOptionsImpl implements _FeedOptions {
+  const _$FeedOptionsImpl(
+      {this.before,
+      this.after,
+      @JsonKey(name: 'page_size') this.pageSize,
+      this.status,
+      this.source,
+      this.tenant,
+      @JsonKey(name: 'has_tenant') this.hasTenant,
+      this.archived = FeedOptionsArchivedScope.exclude,
+      final Map<String, dynamic>? triggerData})
+      : _triggerData = triggerData;
+
+  @override
+  final String? before;
+  @override
+  final String? after;
+  @override
+  @JsonKey(name: 'page_size')
+  final int? pageSize;
+  @override
+  final FeedOptionsStatus? status;
+  @override
+  final String? source;
+  @override
+  final String? tenant;
+  @override
+  @JsonKey(name: 'has_tenant')
+  final bool? hasTenant;
+  @override
+  @JsonKey()
+  final FeedOptionsArchivedScope archived;
+  final Map<String, dynamic>? _triggerData;
+  @override
+  Map<String, dynamic>? get triggerData {
+    final value = _triggerData;
+    if (value == null) return null;
+    if (_triggerData is EqualUnmodifiableMapView) return _triggerData;
+    // ignore: implicit_dynamic_type
+    return EqualUnmodifiableMapView(value);
+  }
+
+  @override
+  String toString() {
+    return 'FeedOptions(before: $before, after: $after, pageSize: $pageSize, status: $status, source: $source, tenant: $tenant, hasTenant: $hasTenant, archived: $archived, triggerData: $triggerData)';
+  }
+
+  @override
+  bool operator ==(dynamic other) {
+    return identical(this, other) ||
+        (other.runtimeType == runtimeType &&
+            other is _$FeedOptionsImpl &&
+            (identical(other.before, before) || other.before == before) &&
+            (identical(other.after, after) || other.after == after) &&
+            (identical(other.pageSize, pageSize) ||
+                other.pageSize == pageSize) &&
+            (identical(other.status, status) || other.status == status) &&
+            (identical(other.source, source) || other.source == source) &&
+            (identical(other.tenant, tenant) || other.tenant == tenant) &&
+            (identical(other.hasTenant, hasTenant) ||
+                other.hasTenant == hasTenant) &&
+            (identical(other.archived, archived) ||
+                other.archived == archived) &&
+            const DeepCollectionEquality()
+                .equals(other._triggerData, _triggerData));
+  }
+
+  @JsonKey(ignore: true)
+  @override
+  int get hashCode => Object.hash(
+      runtimeType,
+      before,
+      after,
+      pageSize,
+      status,
+      source,
+      tenant,
+      hasTenant,
+      archived,
+      const DeepCollectionEquality().hash(_triggerData));
+
+  @JsonKey(ignore: true)
+  @override
+  @pragma('vm:prefer-inline')
+  _$$FeedOptionsImplCopyWith<_$FeedOptionsImpl> get copyWith =>
+      __$$FeedOptionsImplCopyWithImpl<_$FeedOptionsImpl>(this, _$identity);
+
+  @override
+  Map<String, dynamic> toJson() {
+    return _$$FeedOptionsImplToJson(
+      this,
+    );
+  }
+}
+
+abstract class _FeedOptions implements FeedOptions {
+  const factory _FeedOptions(
+      {final String? before,
+      final String? after,
+      @JsonKey(name: 'page_size') final int? pageSize,
+      final FeedOptionsStatus? status,
+      final String? source,
+      final String? tenant,
+      @JsonKey(name: 'has_tenant') final bool? hasTenant,
+      final FeedOptionsArchivedScope archived,
+      final Map<String, dynamic>? triggerData}) = _$FeedOptionsImpl;
+
+  @override
+  String? get before;
+  @override
+  String? get after;
+  @override
+  @JsonKey(name: 'page_size')
+  int? get pageSize;
+  @override
+  FeedOptionsStatus? get status;
+  @override
+  String? get source;
+  @override
+  String? get tenant;
+  @override
+  @JsonKey(name: 'has_tenant')
+  bool? get hasTenant;
+  @override
+  FeedOptionsArchivedScope get archived;
+  @override
+  Map<String, dynamic>? get triggerData;
+  @override
+  @JsonKey(ignore: true)
+  _$$FeedOptionsImplCopyWith<_$FeedOptionsImpl> get copyWith =>
+      throw _privateConstructorUsedError;
+}

--- a/lib/src/model/feed_options.g.dart
+++ b/lib/src/model/feed_options.g.dart
@@ -1,0 +1,51 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+// coverage:ignore-file
+
+part of 'feed_options.dart';
+
+// **************************************************************************
+// JsonSerializableGenerator
+// **************************************************************************
+
+_$FeedOptionsImpl _$$FeedOptionsImplFromJson(Map<String, dynamic> json) =>
+    _$FeedOptionsImpl(
+      before: json['before'] as String?,
+      after: json['after'] as String?,
+      pageSize: json['page_size'] as int?,
+      status: $enumDecodeNullable(_$FeedOptionsStatusEnumMap, json['status']),
+      source: json['source'] as String?,
+      tenant: json['tenant'] as String?,
+      hasTenant: json['has_tenant'] as bool?,
+      archived: $enumDecodeNullable(
+              _$FeedOptionsArchivedScopeEnumMap, json['archived']) ??
+          FeedOptionsArchivedScope.exclude,
+      triggerData: json['triggerData'] as Map<String, dynamic>?,
+    );
+
+Map<String, dynamic> _$$FeedOptionsImplToJson(_$FeedOptionsImpl instance) =>
+    <String, dynamic>{
+      'before': instance.before,
+      'after': instance.after,
+      'page_size': instance.pageSize,
+      'status': _$FeedOptionsStatusEnumMap[instance.status],
+      'source': instance.source,
+      'tenant': instance.tenant,
+      'has_tenant': instance.hasTenant,
+      'archived': _$FeedOptionsArchivedScopeEnumMap[instance.archived]!,
+      'triggerData': instance.triggerData,
+    };
+
+const _$FeedOptionsStatusEnumMap = {
+  FeedOptionsStatus.unread: 'unread',
+  FeedOptionsStatus.read: 'read',
+  FeedOptionsStatus.unseen: 'unseen',
+  FeedOptionsStatus.seen: 'seen',
+  FeedOptionsStatus.all: 'all',
+};
+
+const _$FeedOptionsArchivedScopeEnumMap = {
+  FeedOptionsArchivedScope.include: 'include',
+  FeedOptionsArchivedScope.exclude: 'exclude',
+  FeedOptionsArchivedScope.only: 'only',
+};

--- a/lib/src/util/date_time.dart
+++ b/lib/src/util/date_time.dart
@@ -1,0 +1,15 @@
+import 'package:json_annotation/json_annotation.dart';
+
+extension DateTimeExtension on DateTime {
+  String apiFormatted() => toUtc().toIso8601String();
+}
+
+class ISO8601DateTimeConverter implements JsonConverter<DateTime, String> {
+  const ISO8601DateTimeConverter();
+
+  @override
+  DateTime fromJson(String json) => DateTime.parse(json);
+
+  @override
+  String toJson(DateTime object) => object.toIso8601String();
+}

--- a/lib/src/util/date_time_extension.dart
+++ b/lib/src/util/date_time_extension.dart
@@ -1,3 +1,0 @@
-extension DateTimeExtension on DateTime {
-  String apiFormatted() => toUtc().toIso8601String();
-}

--- a/test/src/model/feed_test.dart
+++ b/test/src/model/feed_test.dart
@@ -25,6 +25,36 @@ void main() {
     );
   });
 
+  test('Feed knows when it has an inflight request', () {
+    expect(
+      Feed.initialState()
+          .copyWith(networkStatus: NetworkStatus.ready)
+          .requestInFlight,
+      false,
+    );
+
+    expect(
+      Feed.initialState()
+          .copyWith(networkStatus: NetworkStatus.error)
+          .requestInFlight,
+      false,
+    );
+
+    expect(
+      Feed.initialState()
+          .copyWith(networkStatus: NetworkStatus.loading)
+          .requestInFlight,
+      true,
+    );
+
+    expect(
+      Feed.initialState()
+          .copyWith(networkStatus: NetworkStatus.fetchMore)
+          .requestInFlight,
+      true,
+    );
+  });
+
   group('Feed deserializes', () {
     test('user recipients correctly', () {
       final json = jsonDecode('''
@@ -55,7 +85,7 @@ void main() {
         {
           "entries": [
             {
-              "__cursor": "g3QAAAABZAALaW5zZXJ0ZWRfYXR0AAAADWQACl9fc3RydWN0X19kAA9FbGl4aXIuRGF0ZVRpbWVkAAhjYWxlbmRhcmQAE0VsaXhpci5DYWxlbmRhci5JU09kAANkYXlhG2QABGhvdXJhFmQAC21pY3Jvc2Vjb25kaAJiAAx3AWEGZAAGbWludXRlYQhkAAVtb250aGELZAAGc2Vjb25kYR5kAApzdGRfb2Zmc2V0YQBkAAl0aW1lX3pvbmVtAAAAB0V0Yy9VVENkAAp1dGNfb2Zmc2V0YQBkAAR5ZWFyYgAAB-dkAAl6b25lX2FiYnJtAAAAA1VUQw==",
+              "__cursor": "long_value",
               "__typename": "FeedItem",
               "activities": [
                 {
@@ -174,13 +204,14 @@ void main() {
       // Start with the top level data...will check activities, actors, and blocks next
       expect(
         item.copyWith(activities: [], actors: [], blocks: []),
-        const FeedItem(
+        FeedItem(
+          knockInternalCursor: 'long_value',
           id: '2YmFaQ8EGs2p1T4usnQW5TzTQlA',
           activities: [],
           actors: [],
           blocks: [],
-          insertedAt: '2023-11-27T22:08:30.816897Z',
-          updatedAt: '2023-11-27T22:24:35.547189Z',
+          insertedAt: DateTime.parse('2023-11-27T22:08:30.816897Z'),
+          updatedAt: DateTime.parse('2023-11-27T22:24:35.547189Z'),
           seenAt: null,
           readAt: null,
           archivedAt: null,
@@ -189,7 +220,7 @@ void main() {
           data: {
             'project_name': 'My Project',
           },
-          source: NotificationSource(
+          source: const NotificationSource(
             key: 'new-comment',
             versionId: '3da6b2de-8d09-470d-8d24-076055696f64',
           ),
@@ -203,8 +234,8 @@ void main() {
         item.activities[0],
         Activity(
           id: '2YmFaQ1DBIl0Km6TyGgpforc1KP',
-          insertedAt: '2023-11-27T22:08:30.795658Z',
-          updatedAt: '2023-11-27T22:08:30.795658Z',
+          insertedAt: DateTime.parse('2023-11-27T22:08:30.795658Z'),
+          updatedAt: DateTime.parse('2023-11-27T22:08:30.795658Z'),
           recipient: Recipient.user(
             User(
               id: '2',

--- a/test/src/util/date_time_test.dart
+++ b/test/src/util/date_time_test.dart
@@ -1,5 +1,5 @@
 import 'package:flutter_test/flutter_test.dart';
-import 'package:knock_flutter/src/util/date_time_extension.dart';
+import 'package:knock_flutter/src/util/date_time.dart';
 
 void main() {
   test('DateTimeExtension formats timestamps to ISO 8601', () {


### PR DESCRIPTION
Example app:
- example/pubspec.yaml: Pulling in `flutter_html` to preview the feed item bodies. You can ignore the next few files.
  - example/pubspec.lock
  - example/ios/Flutter/Debug.xcconfig
  - example/ios/Flutter/Release.xcconfig
  - example/ios/Podfile
- example/lib/main.dart: 
  - Simplifying the list view, 
  - Removing SDK interactions that didn't need to be there from the previous PR
  - Adding in infinite scroll/fetch next page.

Feed updates:
- lib/src/feed_client.dart
  - Updated the markAs* and markAllAs* to hit the correct endpoints and removed the operations that shouldn't have been there.
- lib/src/model/feed.dart
  - Eliminated an unnecessary stream since we are only responding to 'new-message' events from the channel, and the other is for broadcasting local events (upcoming PR).
  - Moved all of the timestamps to DateTime vs String

Misc:
- Any *.freezed.dart or *.g.dart files can be ignored for review.
- Any TODOs I've tagged with Linear tickets.

![Screenshot_1701465124](https://github.com/knocklabs/knock-flutter/assets/424944/e4823c22-037b-4100-a8c5-6fe9197d9acc)
