### PR TITLE
fix: updated `flutter_timezone` version

### DIFF
--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -61,10 +61,10 @@ packages:
     dependency: transitive
     description:
       name: equatable
-      sha256: c2b87cb7756efdf69892005af546c56c0b5037f54d2a88269b4f347a505e3ca2
+      sha256: "3e0141505477fd8ad55d6eb4e7776d3fe8430be8e497ccb1521370c3f21a3e2b"
       url: "https://pub.dev"
     source: hosted
-    version: "2.0.5"
+    version: "2.0.8"
   fake_async:
     dependency: transitive
     description:
@@ -103,10 +103,10 @@ packages:
     dependency: transitive
     description:
       name: flutter_timezone
-      sha256: "0cb5498dedfaac615c779138194052f04524c31d958fab33d378f22b6cc14686"
+      sha256: "978192f2f9ea6d019a4de4f0211d76a9af955ca24865828fa98ca4e20cf0cb3c"
       url: "https://pub.dev"
     source: hosted
-    version: "2.1.0"
+    version: "5.0.1"
   flutter_web_plugins:
     dependency: transitive
     description: flutter
@@ -227,10 +227,10 @@ packages:
     dependency: transitive
     description:
       name: meta
-      sha256: "23f08335362185a5ea2ad3a4e597f1375e78bce8a040df5c600c8d3552ef2394"
+      sha256: e3641ec5d63ebf0d9b41bd43201a66e3fc79a65db5f61fc181f04cd27aab950c
       url: "https://pub.dev"
     source: hosted
-    version: "1.17.0"
+    version: "1.16.0"
   path:
     dependency: transitive
     description:
@@ -320,10 +320,10 @@ packages:
     dependency: transitive
     description:
       name: test_api
-      sha256: ab2726c1a94d3176a45960b6234466ec367179b87dd74f1611adb1f3b5fb9d55
+      sha256: "522f00f556e73044315fa4585ec3270f1808a4b186c936e612cab0b565ff1e00"
       url: "https://pub.dev"
     source: hosted
-    version: "0.7.7"
+    version: "0.7.6"
   typed_data:
     dependency: transitive
     description:

--- a/lib/src/user_client.dart
+++ b/lib/src/user_client.dart
@@ -85,7 +85,7 @@ class UserClient {
     String token,
   ) async {
     final locale = PlatformDispatcher.instance.locale.toLanguageTag();
-    String? timezone;
+    TimezoneInfo? timezone;
     try {
       timezone = await FlutterTimezone.getLocalTimezone();
     } catch (error) {
@@ -115,7 +115,7 @@ class UserClient {
       final device = Device(
         token: token,
         locale: locale,
-        timezone: timezone,
+        timezone: timezone?.identifier,
       );
       final modifiedChannelData = channelData.appendDevice(device);
       return setChannelData(channelId, modifiedChannelData);

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -10,7 +10,7 @@ environment:
 dependencies:
   flutter:
     sdk: flutter
-  flutter_timezone: ^2.1.0
+  flutter_timezone: ^5.0.1
   freezed_annotation: ^2.4.1
   http: ^1.1.0
   json_annotation: ^4.8.1


### PR DESCRIPTION
## Context

The current version of the package relies on a version of `flutter_timezone` that contains a deprecated reference which breaks Android builds.  
See: https://github.com/tjarvstrand/flutter_timezone/issues/49

## Changes
- Updated `flutter_timezone` to the latest version (5.0.1)
- Updated the return type of `FlutterTimezone.getLocalTimezone()`.  
  This method now returns a [`TimezoneInfo`](https://pub.dev/documentation/flutter_timezone/latest/timezone_info/TimezoneInfo-class.html) object, which contains the standardized IANA identifier for the current timezone in the `identifier` property.